### PR TITLE
Revert an Unsaved Reminder

### DIFF
--- a/app/components/edit-reminder.js
+++ b/app/components/edit-reminder.js
@@ -7,11 +7,11 @@ export default Ember.Component.extend({
       model.save();
       this.sendAction();
     },
-    rollbackChanges() {
-      // if(model.get('hasDirtyAttributes')) {
-      //   model.rollbackChanges();
-      // }
-      console.log('boom');
+    rollbackChanges(model) {
+      if(model.get('hasDirtyAttributes')) {
+        model.rollbackAttributes();
+      }
+      this.sendAction();
     }
   }
 });

--- a/app/components/edit-reminder.js
+++ b/app/components/edit-reminder.js
@@ -6,6 +6,12 @@ export default Ember.Component.extend({
       model.date = model.date || new Date();
       model.save();
       this.sendAction();
+    },
+    rollbackChanges() {
+      // if(model.get('hasDirtyAttributes')) {
+      //   model.rollbackChanges();
+      // }
+      console.log('boom');
     }
   }
 });

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Remember</title>
+    <title>RemEMBER</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/routes/reminders/reminder/edit.js
+++ b/app/routes/reminders/reminder/edit.js
@@ -4,6 +4,9 @@ export default Ember.Route.extend({
   actions: {
     editReminder() {
       this.transitionTo('reminders');
+    },
+    rollbackChanges() {
+      this.transitionTo('reminders');
     }
   }
 });

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -3,5 +3,5 @@
   <label>Date:{{input class='edit-reminder-date' value=model.date type='date'}}</label>
   <label>Notes:{{input class='edit-reminder-note' value=model.notes}}</label>
   <button class='spec-edit-save-btn'>Submit</button>
-  <button {{action 'rollbackChanges' model on='click'  }}class='spec-edit-destroy-btn'>Undo</button>
+  <button {{action 'rollbackChanges' model on='click'}} class='spec-edit-destroy-btn'>Undo</button>
 </form>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -3,5 +3,5 @@
   <label>Date:{{input class='edit-reminder-date' value=model.date type='date'}}</label>
   <label>Notes:{{input class='edit-reminder-note' value=model.notes}}</label>
   <button class='spec-edit-save-btn'>Submit</button>
-  <button class='spec-edit-destroy-btn'>Undo</button>
+  <button {{action 'rollbackChanges' model on='click'  }}class='spec-edit-destroy-btn'>Undo</button>
 </form>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -3,5 +3,5 @@
   <label>Date:{{input class='edit-reminder-date' value=model.date type='date'}}</label>
   <label>Notes:{{input class='edit-reminder-note' value=model.notes}}</label>
   <button class='spec-edit-save-btn'>Submit</button>
-  <button {{action 'rollbackChanges' model on='click'}} class='spec-edit-destroy-btn'>Undo</button>
+  <button {{action 'rollbackChanges' model}} class='spec-edit-destroy-btn'>Undo</button>
 </form>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -3,4 +3,5 @@
   <label>Date:{{input class='edit-reminder-date' value=model.date type='date'}}</label>
   <label>Notes:{{input class='edit-reminder-note' value=model.notes}}</label>
   <button class='spec-edit-save-btn'>Submit</button>
+  <button class='spec-edit-destroy-btn'>Undo</button>
 </form>

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -3,7 +3,7 @@
   <h4 class='spec-reminder-date'>{{model.date}}</h4>
   <p class='spec-reminder-notes'>{{model.notes}}</p>
   {{#link-to "reminders.reminder.edit"}}
-    <button class='spec-edit-reminder' >Edit</button>
+    <button class='spec-edit-reminder'>Edit</button>
   {{/link-to}}
 </div>
 

--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -1,1 +1,1 @@
-{{edit-reminder model=model}}
+{{edit-reminder model=model action='editReminder' action='rollbackChanges'}}

--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -1,1 +1,1 @@
-{{edit-reminder model=model action='editReminder'}}
+{{edit-reminder model=model}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -134,19 +134,27 @@ test('clicking the Undo button in the edit form reverts to the original', functi
   visit('/');
   click('.spec-add-new-form');
 
-  fillIn('.new-reminder-title', 'Megatron');
-  fillIn('.new-reminder-note', 'I am evil');
-  click('.spec-add-new');
-
-  click('.spec-reminder-item:first');
-
-  click('.spec-edit-reminder');
-
-  fillIn('.edit-reminder-title', 'HotRod');
-
-  click('.spec-edit-destroy-btn');
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/new');
+    fillIn('.new-reminder-title', 'Megatron');
+    fillIn('.new-reminder-note', 'I am evil');
+    click('.spec-add-new');
+    click('.spec-reminder-item:first');
+  });
 
   andThen(function(){
+    assert.equal(currentURL(),'/reminders/1');
+    click('.spec-edit-reminder');
+  });
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/1/edit');
+    fillIn('.edit-reminder-title', 'HotRod');
+    click('.spec-edit-destroy-btn');
+  });
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders');
     assert.equal(find('.spec-reminder-item:first').text().trim(), 'Megatron');
   });
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -129,3 +129,24 @@ test('user should be able to edit the reminder', function(assert) {
     assert.equal(find('.spec-reminder-item:first').text().trim(), 'Jellyfish');
   });
 });
+
+test('clicking the Undo button in the edit form reverts to the original', function(assert){
+  visit('/');
+  click('.spec-add-new-form');
+
+  fillIn('.new-reminder-title', 'Megatron');
+  fillIn('.new-reminder-note', 'I am evil');
+  click('.spec-add-new');
+
+  click('.spec-reminder-item:first');
+
+  click('.spec-edit-reminder');
+
+  fillIn('.edit-reminder-title', 'HotRod');
+
+  click('.spec-edit-destroy-btn');
+
+  andThen(function(){
+    assert.equal(find('.spec-reminder-item:first').text().trim(), 'Megatron');
+  });
+});


### PR DESCRIPTION
@martensonbj @Tman22 @dylanavery720 

## Purpose

This feature allows the user to undo possible changes to a reminder while they are in the edit form, sending them back to the reminders route.

🏌️  fixes #12              ⛳️ 

## Approach

We created an undo button on the edit form with an action 'rollbackChanges' on click. Then we created an action called rollbackChanges in the component dir that rolls back the attributes if the model has 'dirty attributes' and calls sendAction() to transition the user back to reminders.  

### Learning

We researched using the Ember Data API docs.

[property_hasDirtyAttributes](http://emberjs.com/api/data/classes/DS.Model.html#property_hasDirtyAttributes)

[method_rollbackAttributes](http://emberjs.com/api/data/classes/DS.Model.html#method_rollbackAttributes)

### Test coverage 

Our test runs through a scenario where a user creates a new reminder, then opens the edit form on that reminder, and lastly decides to select undo after adding a new title. The test checks that after all this the title is still the original. This test is passing. :martial_arts_uniform: 

### Follow-up tasks

- [Issue #13](https://github.com/turingschool-projects/1610-remember-2/issues/13)

### Screenshots

[After](http://imgur.com/GBsnm6V)