### PR TITLE
Visual cues

### DIFF
--- a/app/components/add-reminder.js
+++ b/app/components/add-reminder.js
@@ -9,10 +9,11 @@ export default Ember.Component.extend({
   title: '',
   date: '',
   notes: '',
+  edit: false,
 
   actions: {
     createReminder() {
-      const reminder = this.getProperties('title', 'date', 'notes');
+      const reminder = this.getProperties('title', 'date', 'notes', 'edit');
       reminder.date = new Date(reminder.date);
       this.get('store').createRecord('reminder', reminder).save()
       .then(() => {

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -4,6 +4,5 @@ export default DS.Model.extend({
   title: DS.attr('string'),
   date: DS.attr('date'),
   notes: DS.attr('string'),
-  pinned: DS.attr('boolean', { defaultValue: false }),
-  edit: DS.attr('boolean')
+  pinned: DS.attr('boolean', { defaultValue: false })
 });

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -4,5 +4,6 @@ export default DS.Model.extend({
   title: DS.attr('string'),
   date: DS.attr('date'),
   notes: DS.attr('string'),
-  pinned: DS.attr('boolean', { defaultValue: false })
+  pinned: DS.attr('boolean', { defaultValue: false }),
+  edit: DS.attr('boolean')
 });

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -3,6 +3,5 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   title: DS.attr('string'),
   date: DS.attr('date'),
-  notes: DS.attr('string'),
-  pinned: DS.attr('boolean', { defaultValue: false })
+  notes: DS.attr('string')
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -7,9 +7,9 @@ form {
 }
 
 #spec-edit-status {
-  color: pink;
+  color: red;
 }
 
 .unsaved {
-  background-color: #F05A76;
+  background-color: #F48A9E;
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -5,3 +5,7 @@
 form {
   margin-top: 30px;
 }
+
+#spec-edit-status {
+  color: pink;
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -9,3 +9,7 @@ form {
 #spec-edit-status {
   color: pink;
 }
+
+.unsaved {
+  background-color: #F05A76;
+}

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -5,3 +5,7 @@
   <button class='spec-edit-save-btn'>Submit</button>
   <button {{action 'rollbackChanges' model}} class='spec-edit-destroy-btn'>Undo</button>
 </form>
+
+{{#if edit}}
+  <p id="spec-edit-status">You have unsaved changes!</p>
+{{/if}}

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -7,5 +7,5 @@
 </form>
 
 {{#if edit}}
-  <p id="spec-edit-status">You have unsaved changes!</p>
+  <p id="spec-edit-status">Do not forget to save your changes!</p>
 {{/if}}

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -6,6 +6,4 @@
   <button {{action 'rollbackChanges' model}} class='spec-edit-destroy-btn'>Undo</button>
 </form>
 
-{{#if edit}}
-  <p id="spec-edit-status">Do not forget to save your changes!</p>
-{{/if}}
+<p id="spec-edit-status">Do not forget to save your changes!</p>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -3,7 +3,7 @@
 {{#if model}}
   {{#each model as |reminder|}}
     <ul class='reminders-list'>
-      <li>
+      <li class={{if reminder.hasDirtyAttributes "unsaved"}}>
         {{#link-to 'reminders.reminder' reminder.id}}
           <h3 class='spec-reminder-item'>{{reminder.title}}</h3>
         {{/link-to}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -3,7 +3,7 @@
 {{#if model}}
   {{#each model as |reminder|}}
     <ul class='reminders-list'>
-      <li class={{if reminder.hasDirtyAttributes "unsaved"}}>
+      <li class={{if reminder.hasDirtyAttributes 'unsaved'}}>
         {{#link-to 'reminders.reminder' reminder.id}}
           <h3 class='spec-reminder-item'>{{reminder.title}}</h3>
         {{/link-to}}

--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -1,1 +1,1 @@
-{{edit-reminder model=model edit=true action='editReminder' action='rollbackChanges'}}
+{{edit-reminder model=model action='editReminder' action='rollbackChanges'}}

--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -1,1 +1,1 @@
-{{edit-reminder model=model action='editReminder' action='rollbackChanges'}}
+{{edit-reminder model=model edit=true action='editReminder' action='rollbackChanges'}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -158,3 +158,25 @@ test('clicking the Undo button in the edit form reverts to the original', functi
     assert.equal(find('.spec-reminder-item:first').text().trim(), 'Megatron');
   });
 });
+
+test('User is alerted that they have unsaved changes when view the edit form', function(assert){
+  visit('/');
+  click('.spec-add-new-form');
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/new');
+    fillIn('.new-reminder-title', 'Blue Whale');
+    click('.spec-add-new');
+    click('.spec-reminder-item:first');
+  });
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/1');
+    click('.spec-edit-reminder');
+  });
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/1/edit');
+    assert.equal(find('#spec-edit-status').text().trim(), 'You have unsaved changes!');
+  });
+});

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -159,7 +159,7 @@ test('clicking the Undo button in the edit form reverts to the original', functi
   });
 });
 
-test('User is alerted that they have unsaved changes when view the edit form', function(assert){
+test('User is instructed to save their changes when viewing the edit form', function(assert){
   visit('/');
   click('.spec-add-new-form');
 
@@ -177,6 +177,41 @@ test('User is alerted that they have unsaved changes when view the edit form', f
 
   andThen(function(){
     assert.equal(currentURL(),'/reminders/1/edit');
-    assert.equal(find('#spec-edit-status').text().trim(), 'You have unsaved changes!');
+    assert.equal(find('#spec-edit-status').text().trim(), 'Do not forget to save your changes!');
+  });
+});
+
+test('A visual cue lets the user know they have unsaved changes when editing a specific reminder', function(assert) {
+  visit('/');
+  click('.spec-add-new-form');
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/new');
+  });
+
+  fillIn('.new-reminder-title', 'Learn Ember');
+  click('.spec-add-new');
+  click('.spec-reminder-item:first');
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/1');
+  });
+
+  click('.spec-edit-reminder');
+
+  andThen(function() {
+    assert.equal(find('.unsaved').length, 0, 'reminder should not have the unsaved class yet');
+  });
+
+  fillIn('.edit-reminder-title', 'Practice es6');
+
+  andThen(function() {
+    assert.equal(find('.unsaved').length, 1, 'reminder being edited will now have the unsaved class');
+  });
+
+  click('.spec-edit-save-btn');
+
+  andThen(function() {
+    assert.equal(find('.unsaved').length, 0, 'reminder should no longer have the unsaved class');
   });
 });


### PR DESCRIPTION
@martensonbj @Tman22 @dylanavery720 🐝 

## Purpose

The feature alerts the user that they must save their changes when using the edit form for a specific reminder.

❤️  fixes #13  💍  

## Approach

We created a new boolean when each reminder is created, edit set to false. On the edit hbs edit is switched to true and passed to the edit-reminder hbs. The edit-reminder hbs checks if edit is true and if so it renders the p tag 'You have unsaved changes!'.

### Learning

We learned how to add a new property to each reminder. Also, how to render an html element using the Ember if conditional {{if}}.

[Ember if conditional](https://guides.emberjs.com/v2.10.0/templates/conditionals/)

### Test coverage 

Our test is a scenario where the user adds and new reminder then clicks the edit on that specific reminder. Our test then checks to make sure that our visual cue is rendering.

### Follow-up tasks

- [Issue #14](https://github.com/turingschool-projects/1610-remember-2/issues/14)

### Screenshots

[After](http://imgur.com/PZynCXW)