### PR TITLE
Remove reminder

### DIFF
--- a/app/controllers/reminders.js
+++ b/app/controllers/reminders.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+    actions: {
+      remove(id){
+        this.get('store').findRecord('reminder', id, {
+          backgroundReload: false
+        })
+       .then((post) => {
+         post.destroyRecord();
+       })
+       .then(() => {
+         this.transitionTo('reminders')
+       })
+      }
+    }
+});

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+    actions: {
+      remove(id){
+        this.get('store').findRecord('reminder', id, {
+          backgroundReload: false
+        })
+       .then((post) => {
+         post.destroyRecord();
+       })
+       .then(() => {
+         this.transitionToRoute('reminders')
+       })
+      }
+    }
+});

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -5,3 +5,8 @@
 form {
   margin-top: 30px;
 }
+
+.spec-remove-reminder, .spec-reminder-item {
+  display: inline-block;
+  margin-right: 10px;
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -7,6 +7,7 @@
         {{#link-to 'reminders.reminder' reminder.id}}
           <h3 class='spec-reminder-item'>{{reminder.title}}</h3>
         {{/link-to}}
+        <button class='spec-remove-reminder' {{action 'remove' reminder.id}}>X</button>
       </li>
     </ul>
   {{/each}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,4 +1,5 @@
 <div>
+  <button class='spec-remove-reminder' {{action 'remove' model.id}}>X</button>
   <h3 class='spec-reminder-title'>{{model.title}}</h3>
   <h4 class='spec-reminder-date'>{{model.date}}</h4>
   <p class='spec-reminder-notes'>{{model.notes}}</p>

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,5 +1,5 @@
 <div>
-  <button class='spec-remove-reminder' {{action 'remove' model.id}}>X</button>
+  <button id='spec-remove-reminder' {{action 'remove' model.id}}>X</button>
   <h3 class='spec-reminder-title'>{{model.title}}</h3>
   <h4 class='spec-reminder-date'>{{model.date}}</h4>
   <p class='spec-reminder-notes'>{{model.notes}}</p>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -215,3 +215,45 @@ test('A visual cue lets the user know they have unsaved changes when editing a s
     assert.equal(find('.unsaved').length, 0, 'reminder should no longer have the unsaved class');
   });
 });
+
+test('clicking the X reminder on the cardbutton removes a reminder', function(assert){
+
+  visit('/');
+  click('.spec-add-new-form');
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/new');
+  });
+
+  fillIn('.new-reminder-title', 'Learn Ember');
+  click('.spec-add-new');
+
+  click('.spec-reminder-item:first');
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders/1');
+  });
+
+  click('#spec-remove-reminder');
+  andThen(function(){
+    assert.equal(find('.spec-reminder-item').length, 0);
+  });
+});
+
+
+test('clicking the X reminder button on a link removes a reminder', function(assert){
+
+  visit('/');
+  click('.spec-add-new-form');
+
+  andThen(function(){
+    assert.equal(currentURL(),'/reminders/new');
+  });
+
+  fillIn('.new-reminder-title', 'Learn Ember');
+  click('.spec-add-new');
+
+  click('.spec-remove-reminder');
+  andThen(function(){
+    assert.equal(find('.spec-reminder-item').length, 0);
+  });
+});


### PR DESCRIPTION
@martensonbj @Tman22 @adam-rice 

## Purpose

Add a delete button on both the link and the reminder card so that it can be removed from the database and the view at the same time. 💀 closes #14 💀 

## Approach

We added controllers that have delete functionality and then passed the delete action down to buttons inside of our templates.

### Learning

We read the Ember docs but mostly it was just common sense.

### Test coverage 

We wrote a test to check the delete functionality of both of our delete buttons, by checking to see that our reminder length was at 0 after button click.


🌰
 :1st_place_medal: 
🌯  
☠️  🏴 
📿   